### PR TITLE
Change staging domain name

### DIFF
--- a/deployment/staging.md
+++ b/deployment/staging.md
@@ -5,7 +5,7 @@ for smaller apps. The following things differ between production and staging:
 
 # Domain convention
 
-Use `staging-appname.standout.se` or `staging.realappdomain.com`
+Use `appname.staging.standout.se` or `staging.realappdomain.com`
 
 # Databases
 


### PR DESCRIPTION
Most of our apps do not use `staging-appname.standout.se` they are instead using `appname.staging.standout.se?`. This commit will change the document to match how we really set our names.

Of all staging domains we hav only 2 of them are using the `staging-appname`-pattern.