### PR TITLE
Exclude block length for rails config

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -20,6 +20,10 @@ Metrics/LineLength:
   Exclude:
     - "config/**/*"
 
+Metrics/BlockLength:
+  Exclude:
+    - "config/environments/**/*"
+
 Style/ClassAndModuleChildren:
   Enabled: false
 


### PR DESCRIPTION
Configuration block tend to be long after a while and should be
excluded from Rubocop.