### PR TITLE
Update rubocop config to allow non-ascii comments

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -24,6 +24,9 @@ Metrics/BlockLength:
   Exclude:
     - "config/environments/**/*"
 
+Style/AsciiComments:
+  Enabled: false
+
 Style/ClassAndModuleChildren:
   Enabled: false
 


### PR DESCRIPTION
For the occasional comment containing åäö.