### PR TITLE
Fix Style/* has wrong namespace should be Layout

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -16,6 +16,15 @@ AllCops:
 Rails:
   Enabled: true
 
+Layout/IndentHash:
+  EnforcedStyle: consistent
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+
 Metrics/LineLength:
   Exclude:
     - "config/**/*"
@@ -38,17 +47,8 @@ Style/Documentation:
 Style/DoubleNegation:
   Enabled: false
 
-Style/IndentHash:
-  EnforcedStyle: consistent
-
-Style/SpaceAroundEqualsInParameterDefault:
-  EnforcedStyle: no_space
-
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Style/TrivialAccessors:
   AllowPredicates: true
-
-Style/SpaceBeforeFirstArg:
-  Enabled: false


### PR DESCRIPTION
RuboCop warns that the following have the wrong namespace:

- `Style/IndentHash has the wrong namespace`
- `Style/SpaceAroundEqualsInParameterDefault has the wrong namespace`
- `Style/SpaceBeforeFirstArg has the wrong namespace`