### PR TITLE
Re-enable Layout/SpaceBeforeFirstArg rubocop

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -22,9 +22,6 @@ Layout/IndentHash:
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 
-Layout/SpaceBeforeFirstArg:
-  Enabled: false
-
 Metrics/LineLength:
   Exclude:
     - "config/**/*"


### PR DESCRIPTION
It was disabled in 99390675 while known as Style/SingleSpaceBeforeFirstArg.

According to https://github.com/standout/Coding/pull/23#discussion_r176849938

Documentation here http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/SpaceBeforeFirstArg