### PR TITLE
Disable Lint/AmbiguousBlockAssociation for specs

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -22,6 +22,10 @@ Layout/IndentHash:
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
 Metrics/LineLength:
   Exclude:
     - "config/**/*"


### PR DESCRIPTION
Lint/AmbiguousBlockAssociation: Parenthesize the param change { ... } to
make sure that the block will be associated with the change method call.

https://github.com/bbatsov/rubocop/issues/4222