### PR TITLE
Add nanobox postgres9 backup script

### DIFF
--- a/nanobox/backup-scripts/README.md
+++ b/nanobox/backup-scripts/README.md
@@ -1,0 +1,68 @@
+# Nanobox backup scripts
+
+Each backup script can be used in your boxfile.yaml. A few environment
+variables needs to be set in your nanobox environment or before you execute the
+script.
+
+All backups should be uploaded to a S3 server. This is common for most backup
+scripts you will find in this directory.
+
+Make sure that your nanobox environment has the following environment variables
+set before you continue.
+
+- AWS_S3_ENDPOINT_URL
+- AWS_S3_BACKUP_BUCKET
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_ACCESS_KEY
+
+To add an environment variable to the nanobox environment
+
+```
+$ nanobox evar add NAME_OF_YOUR_NANOBOX_APP MY_EVAR=myvalue
+```
+
+Each component that is using the backup scripts will also need awscli. You can install that by adding `py36-awscli` as an extra package like this.
+
+```yaml
+data.name:
+  image: imagename
+  extra_packages:
+    - py36-awscli
+```
+
+
+## Postgres 9
+
+The script expects that your postgresql component is named `data.db`. It should
+like similar to this without backups configurated.
+
+```yaml
+data.db:
+  image: nanobox/postgresql:9.6
+```
+
+**You must** make sure that the environment variable `DATABASE_NAME` is correct. It will default to backup the database named `gonano` unless you override that by setting the `DATABASE_NAME` variable before you execute the script using bash. You could also set the variable directly to the nanobox environment like this.
+
+```
+$ nanobox evar add NAME_OF_YOUR_NANOBOX_APP DATABASE_NAME=foobar
+```
+
+To backup once you could run
+
+```
+$ curl -fsSL https://raw.githubusercontent.com/standout/Coding/master/nanobox/backup-scripts/postgres9.sh | DATABASE_NAME=foobar bash
+```
+
+To backup each night at 03:00 you should change your comoponent in the boxfile to look like this
+
+```yaml
+data.db:
+  image: nanobox/postgresql:9.6
+  extra_packages:
+    - py36-awscli
+  cron:
+    - id: backup
+      schedule: '0 3 * * *'
+      command: curl -fsSL https://raw.githubusercontent.com/standout/Coding/master/nanobox/backup-scripts/postgres9.sh | DATABASE_NAME=foobar bash
+```
+

--- a/nanobox/backup-scripts/postgres9.sh
+++ b/nanobox/backup-scripts/postgres9.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# This script should be used to backup your postgresql 9 database
+#
+# Following environment variables is needed to be set
+#
+# DATABASE_NAME
+#
+#     The database you would like to backup, defaults to gonano
+#
+# AWS_S3_ENDPOINT_URL
+#
+#     The amazon s3 endpoint
+#
+# AWS_S3_BACKUP_BUCKET
+#
+#     The name of the bucket you would like to store the backups in.
+#     Example "yourapp/backups"
+#
+# AWS_ACCESS_KEY_ID
+#
+#     Access key id
+#
+# AWS_SECRET_ACCESS_KEY
+#
+#     Secret access key
+#
+#
+# Example usage:
+#
+#     data.db:
+#       image: nanobox/postgresql:9.6
+#       extra_packages:
+#         - py36-awscli
+#       cron:
+#         - id: backup
+#           schedule: '0 3 * * *'
+#           command: curl -fsSL https://raw.githubusercontent.com/standout/Coding/master/nanobox/backup-scripts/postgres9.sh | DATABASE_NAME=foobar bash
+
+date=$(date -u +%Y-%m-%d.%H-%M-%S) ;
+(
+  PGPASSWORD=${DATA_DB_PASS} pg_dump -w -Fc -O -U ${DATA_DB_USER} ${DATABASE_NAME} |
+  gzip |
+  tee >(cat - >&4) |
+  curl -k -H "X-AUTH-TOKEN: ${WAREHOUSE_DATA_HOARDER_TOKEN}" https://${WAREHOUSE_DATA_HOARDER_HOST}:7410/blobs/backup-${HOSTNAME}-${date}.sql.gz --data-binary @- >&2
+) 4>&1 |
+aws --endpoint-url ${AWS_S3_ENDPOINT_URL} s3 cp - s3://${AWS_S3_BACKUP_BUCKET}/${APP_NAME}-backup-${HOSTNAME}-${date}.sql.gz ;
+curl -k -s -H "X-AUTH-TOKEN: ${WAREHOUSE_DATA_HOARDER_TOKEN}" https://${WAREHOUSE_DATA_HOARDER_HOST}:7410/blobs/ |
+json_pp |
+grep ${HOSTNAME} |
+sort |
+head -n-${BACKUP_COUNT:-5} | # Change the env var BACKUP_COUNT to change how many backups should be saved
+sed 's/.*: "\(.*\)".*/\1/' |
+while read file
+do
+  curl -k -H "X-AUTH-TOKEN: ${WAREHOUSE_DATA_HOARDER_TOKEN}" https://${WAREHOUSE_DATA_HOARDER_HOST}:7410/blobs/${file} -X DELETE
+  aws --endpoint-url ${AWS_S3_ENDPOINT_URL} s3 rm s3://${AWS_S3_BACKUP_BUCKET}/${APP_NAME}-${file}
+done
+


### PR DESCRIPTION
Huvudproblemet med backup av databaser i våra projekt är att den backuppar en databas som heter gonano. Oftast använder vi ju inte den databasen som nanobox skapat åt oss utan vi kör på till exempel `projektnamn_production`. Med hjälp av detta scriptet kan vi se till att alla våra miljöer får en uppdaterad version av backuplösningen i samband med bakup.

Fördelar:

- En up to date backuplösning per projekt
- Med hjälp av GitHub går det även att låsa versionen genom att låte URL innehålla commit-hash när man kör curl

Nackdelar:

- Backup är beroende av att GitHub är online