### PR TITLE
Disable block length check in rake tasks

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -35,6 +35,8 @@ Metrics/BlockLength:
     - "config/environments/**/*"
     - "spec/**/*.rb"
     - "test/**/*.rb"
+    - "lib/tasks/**/*.rake"
+    - "Rakefile"
 
 Style/AsciiComments:
   Enabled: false


### PR DESCRIPTION
Rake tasks, with namespaces, have tendency to be long. We should disable block length check for them.