### PR TITLE
Update rubocop for newer versions

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  NewCops: disable
   DisplayCopNames: true
   DisplayStyleGuide: true
   Exclude:
@@ -34,6 +35,7 @@ Metrics/BlockLength:
     - test/**/*.rb
 
 Layout/LineLength:
+  Max: 80
   Exclude:
     - db/schema.rb
 


### PR DESCRIPTION
Syftet med denna PR är att tvinga 80 tecken, för att kunna uppdatera `rubocop` i de projekt vi har utan att få 120 tecken som maxgräns gällande radlängd. 
Även stödja de nya reglerna som kommer in. 